### PR TITLE
extend update event to provide range of the visible items

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ When the user scrolls inside RecycleScroller, the views are mostly just moved ar
 - `resize`: emitted when the size of the scroller changes.
 - `visible`: emitted when the scroller considers itself to be visible in the page.
 - `hidden`: emitted when the scroller is hidden in the page.
-- `update (startIndex, endIndex)`: emitted each time the views are updated, only if `emitUpdate` prop is `true`
+- `update (startIndex, endIndex, visibleStartIndex, visibleEndIndex)`: emitted each time the views are updated, only if `emitUpdate` prop is `true`
 
 ### Default scoped slot props
 

--- a/docs-src/src/components/DynamicScrollerDemo.vue
+++ b/docs-src/src/components/DynamicScrollerDemo.vue
@@ -1,11 +1,20 @@
 <template>
   <div class="dynamic-scroller-demo">
+    <div class="toolbar">
+      <label>
+        <input v-model="showMessageBeforeItems" type="checkbox" /> show message before items
+      </label>
+      <span>({{updateParts.viewStartIdx}} - [{{updateParts.visibleStartIdx}} - {{updateParts.visibleEndIdx}}] - {{updateParts.viewEndIdx}})</span>
+    </div>
+
     <DynamicScroller
       :items="items"
       :min-item-height="54"
+      :emit-update="true"
+      @update="onUpdate"
       class="scroller"
     >
-      <div slot="before-container" class="notice">
+      <div slot="before-container" class="notice" v-if="showMessageBeforeItems">
         The message heights are unknown.
       </div>
 
@@ -55,12 +64,21 @@ export default {
   data () {
     return {
       items,
+      updateParts: { viewStartIdx: 0, viewEndIdx: 0, visibleStartIdx: 0, visibleEndIdx: 0 },
+      showMessageBeforeItems: true,
     }
   },
 
   methods: {
     changeMessage (message) {
       Object.assign(message, generateMessage())
+    },
+
+    onUpdate (viewStartIndex, viewEndIndex, visibleStartIndex, visibleEndIndex) {
+      this.updateParts.viewStartIdx = viewStartIndex;
+      this.updateParts.viewEndIdx = viewEndIndex;
+      this.updateParts.visibleStartIdx = visibleStartIndex;
+      this.updateParts.visibleEndIdx = visibleEndIndex;
     },
   },
 }
@@ -74,6 +92,19 @@ export default {
 
 .dynamic-scroller-demo {
   overflow: hidden;
+}
+
+.scroller {
+  border: solid 1px #42b983;
+}
+
+.toolbar {
+  flex: auto 0 0;
+  text-align: center;
+}
+
+.toolbar > *:not(:last-child) {
+  margin-right: 24px;
 }
 
 .notice {

--- a/docs-src/src/components/RecycleScrollerDemo.vue
+++ b/docs-src/src/components/RecycleScrollerDemo.vue
@@ -27,6 +27,10 @@
         <button @mousedown="renderScroller = !renderScroller">Toggle render</button>
         <button @mousedown="showScroller = !showScroller">Toggle visibility</button>
       </span>
+      <label>
+        <input v-model="showMessageBeforeItems" type="checkbox" /> show message before items
+      </label>
+      <span>({{updateParts.viewStartIdx}} - [{{updateParts.visibleStartIdx}} - {{updateParts.visibleEndIdx}}] - {{updateParts.viewEndIdx}})</span>
     </div>
 
     <div
@@ -44,9 +48,15 @@
           :buffer="buffer"
           :page-mode="pageMode"
           key-field="id"
+          :emit-update="true"
+          @update="onUpdate"
           @visible="onVisible"
           @hidden="onHidden"
         >
+          <div slot="before-container" class="notice" v-if="showMessageBeforeItems">
+            <span v-if="enableLetters">The message heights are variable.</span>
+            <span v-else>The message heights are fixed.</span>
+          </div>
           <template slot-scope="props">
             <div
               v-if="props.item.type === 'letter'"
@@ -93,6 +103,8 @@ export default {
     enableLetters: true,
     pageMode: false,
     pageModeFullPage: true,
+    updateParts: { viewStartIdx: 0, viewEndIdx: 0, visibleStartIdx: 0, visibleEndIdx: 0 },
+    showMessageBeforeItems: true,
   }),
 
   computed: {
@@ -151,8 +163,11 @@ export default {
       addItem(this.items)
     },
 
-    onUpdate (startIndex, endIndex) {
-      this.updateCount++
+    onUpdate (viewStartIndex, viewEndIndex, visibleStartIndex, visibleEndIndex) {
+      this.updateParts.viewStartIdx = viewStartIndex;
+      this.updateParts.viewEndIdx = viewEndIndex;
+      this.updateParts.visibleStartIdx = visibleStartIndex;
+      this.updateParts.visibleEndIdx = visibleEndIndex;
     },
 
     onVisible () {
@@ -220,6 +235,12 @@ export default {
 .scroller {
   width: 100%;
   height: 100%;
+}
+
+.notice {
+  padding: 24px;
+  font-size: 20px;
+  color: #999;
 }
 
 .letter {


### PR DESCRIPTION
x-pr from https://github.com/AkryumInfinitum/vue-virtual-scroller/compare/master...cplussharp:master

>because of the buffer, the startIdx and endIdx of the update event
>are not the indexes of the visible items but of the loaded items.
>This change extends the update event to also output indexes of the visible items.