### PR TITLE
Modal : Change the "transformX|Y" css property to "top or left" for a fixed position item

### DIFF
--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -27,7 +27,7 @@
         v-for="view of pool"
         :key="view.nr.id"
         :style="ready ? view.item.modal ? {[direction === 'vertical' ? 'top' : 'left'] : `${view.position}px`, willChange : 'unset'} : { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
-        class="vue-recycle-scroller__item-view sometest"
+        class="vue-recycle-scroller__item-view"
         :class="{ hover: hoverKey === view.nr.key }"
         @mouseenter="hoverKey = view.nr.key"
         @mouseleave="hoverKey = null"

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -26,7 +26,7 @@
       <div
         v-for="view of pool"
         :key="view.nr.id"
-        :style="ready ? { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
+        :style="ready ? view.item.modal ? {[direction === 'vertical' ? 'top' : 'left'] : `${view.position}px`, willChange : 'unset'} : { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
         class="vue-recycle-scroller__item-view"
         :class="{ hover: hoverKey === view.nr.key }"
         @mouseenter="hoverKey = view.nr.key"

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -27,7 +27,7 @@
         v-for="view of pool"
         :key="view.nr.id"
         :style="ready ? view.item.modal ? {[direction === 'vertical' ? 'top' : 'left'] : `${view.position}px`, willChange : 'unset'} : { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
-        class="vue-recycle-scroller__item-view"
+        class="vue-recycle-scroller__item-view sometest"
         :class="{ hover: hoverKey === view.nr.key }"
         @mouseenter="hoverKey = view.nr.key"
         @mouseleave="hoverKey = null"


### PR DESCRIPTION
x-pr from https://github.com/Akryum/vue-virtual-scroller/pull/138

> A small change for a particular use case.
>
> The css Transform property create a new scope inside the browser, so the item with fixed position is positioned relatively to the nearest parent with the transform property (.vue-recycle-scroller__item-view) and not the browser itself.
>
> Here I'm adding a "modal" property the the item object, when set to true, it replace "transform (x or y)" with "left or top" depending on the "direction" also unset the css "will-change" property.
>
> Typical use case : zoom in modal for images or video display