### PR TITLE
feat: adds configurable list/item tags for semantic html

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ When the user scrolls inside RecycleScroller, the views are mostly just moved ar
 - `prerender` (default: `0`): render a fixed number of items for Server-Side Rendering.
 - `buffer` (default: `200`): amount of pixel to add to edges of the scrolling visible area to start rendering items further away.
 - `emitUpdate` (default: `false`): emit a `'update'` event each time the virtual scroller content is updated (can impact performance).
+- `listTag` (default: `'div'`): the element to render as the list's wrapper.
+- `itemTag` (default: `'div'`): the element to render as the list item (the direct parent of the default slot content).
 
 ### Events
 

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -4,6 +4,8 @@
     :items="itemsWithSize"
     :min-item-size="minItemSize"
     :direction="direction"
+    :list-tag="listTag"
+    :item-tag="itemTag"
     key-field="id"
     v-bind="$attrs"
     @resize="onScrollerResize"

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -18,12 +18,14 @@
       />
     </div>
 
-    <div
+    <component
+      :is="listTag"
       ref="wrapper"
       :style="{ [direction === 'vertical' ? 'minHeight' : 'minWidth']: totalSize + 'px' }"
       class="vue-recycle-scroller__item-wrapper"
     >
-      <div
+      <component
+        :is="itemTag"
         v-for="view of pool"
         :key="view.nr.id"
         :style="ready ? { transform: `translate${direction === 'vertical' ? 'Y' : 'X'}(${view.position}px)` } : null"
@@ -37,8 +39,8 @@
           :index="view.nr.index"
           :active="view.nr.used"
         />
-      </div>
-    </div>
+      </component>
+    </component>
 
     <div
       v-if="$slots.after"
@@ -115,6 +117,16 @@ export default {
     emitUpdate: {
       type: Boolean,
       default: false,
+    },
+
+    listTag: {
+      type: String,
+      default: 'div',
+    },
+
+    itemTag: {
+      type: String,
+      default: 'div',
     },
   },
 

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -118,16 +118,6 @@ export default {
       type: Boolean,
       default: false,
     },
-
-    listTag: {
-      type: String,
-      default: 'div',
-    },
-
-    itemTag: {
-      type: String,
-      default: 'div',
-    },
   },
 
   data () {

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -14,6 +14,16 @@ export const props = {
     default: 'vertical',
     validator: (value) => ['vertical', 'horizontal'].includes(value),
   },
+
+  listTag: {
+    type: String,
+    default: 'div',
+  },
+
+  itemTag: {
+    type: String,
+    default: 'div',
+  },
 }
 
 export function simpleArray () {


### PR DESCRIPTION
x-pr from https://github.com/Akryum/vue-virtual-scroller/pull/203

> I would like to have the ability to author semantic list element types. For example, I want vue-virtual-scroller to support rendering its virtual list in a `ul>li` tree. This addition adds props (and docs) that support configuring the direct list and list item element types.