### PR TITLE
Fix jumpy scroll

### DIFF
--- a/docs-src/src/components/TestChat.vue
+++ b/docs-src/src/components/TestChat.vue
@@ -10,6 +10,9 @@
       <button @click="addItems(10)">
         Add 10 items
       </button>
+      <button @click="addItems(50)">
+        Add 50 items
+      </button>
     </div>
 
     <DynamicScroller
@@ -25,12 +28,7 @@
         :active="active"
         :data-index="index"
       >
-        <div
-          class="message"
-          :style="{
-            height: `${item.size}px`,
-          }"
-        >
+        <div class="message">
           {{ item.text }}
         </div>
       </DynamicScrollerItem>
@@ -54,9 +52,8 @@ export default {
     addItems (count = 1) {
       for (let i = 0; i < count; i++) {
         this.items.push({
-          text: faker.lorem.sentence(),
+          text: faker.lorem.lines(),
           id: this.items.length + 1,
-          size: Math.random() * 120 + 40,
         })
       }
       this.scrollToBottom()

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -164,7 +164,7 @@ export default {
     },
   },
 
-  created () {
+  beforeCreate () {
     this.$_updates = []
     this.$_undefinedSizes = 0
     this.$_undefinedMap = {}

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -160,7 +160,7 @@ export default {
         return
       }
 
-      this.$el.scrollTop = this.$el.scrollTop + offset
+      this.$el.scrollTop += offset
     },
   },
 

--- a/src/components/DynamicScroller.vue
+++ b/src/components/DynamicScroller.vue
@@ -138,6 +138,30 @@ export default {
     direction (value) {
       this.forceUpdate(true)
     },
+
+    itemsWithSize (next, prev) {
+      const scrollTop = this.$el.scrollTop
+
+      // Calculate total diff between prev and next sizes
+      // over current scroll top. Then add it to scrollTop to
+      // avoid jumping the contents that the user is seeing.
+      let prevActiveTop = 0; let activeTop = 0
+      const length = Math.min(next.length, prev.length)
+      for (let i = 0; i < length; i++) {
+        if (prevActiveTop >= scrollTop) {
+          break
+        }
+        prevActiveTop += prev[i].size || this.minItemSize
+        activeTop += next[i].size || this.minItemSize
+      }
+      const offset = activeTop - prevActiveTop
+
+      if (offset === 0) {
+        return
+      }
+
+      this.$el.scrollTop = this.$el.scrollTop + offset
+    },
   },
 
   created () {


### PR DESCRIPTION
x-pr from https://github.com/Akryum/vue-virtual-scroller/pull/374

> extracted from #248
> fix #248 (comment)
>
> The original issue that #248 tried to solve is already solved on the current master branch but there still is an issue when upper items are loaded.
>
> In the case the current scroll position is bottom and scrolling up, the upper items will be loaded and their size will be set lazily. When the size is set to concrete value, the remaining items will be pushed for bottom, then scroll looks jumpy.
>
> To avoid this, I'm comparing prev and next height of items and add the offset to scrollTop.