### PR TITLE
bugfix: scrollToItem works with pageMode

### DIFF
--- a/docs-src/src/components/RecycleScrollerDemo.vue
+++ b/docs-src/src/components/RecycleScrollerDemo.vue
@@ -43,6 +43,15 @@
         > buffer
       </span>
       <span>
+        <button @mousedown="$refs.scroller.scrollToItem(scrollTo)">Scroll To: </button>
+        <input
+          v-model.number="scrollTo"
+          type="number"
+          min="0"
+          :max="list.length - 1"
+        >
+      </span>
+      <span>
         <button @mousedown="renderScroller = !renderScroller">Toggle render</button>
         <button @mousedown="showScroller = !showScroller">Toggle visibility</button>
       </span>
@@ -113,6 +122,7 @@ export default {
     enableLetters: true,
     pageMode: false,
     pageModeFullPage: true,
+    scrollTo: 100,
   }),
 
   computed: {

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -574,8 +574,8 @@ export default {
 
     scrollToPosition (position) {
       const direction = this.direction === 'vertical'
-        ? { scroll: 'scrollTop', start: 'top', size: 'height' }
-        : { scroll: 'scrollLeft', start: 'left', size: 'width' }
+        ? { scroll: 'scrollTop', start: 'top' }
+        : { scroll: 'scrollLeft', start: 'left' }
 
       if (this.pageMode) {
         const viewportEl = ScrollParent(this.$el)

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -563,16 +563,19 @@ export default {
     },
 
     scrollToItem (index) {
-      let scroll
-      if (this.itemSize === null) {
-        scroll = index > 0 ? this.sizes[index - 1].accumulator : 0
-      } else {
-        scroll = index * this.itemSize
-      }
-      this.scrollToPosition(scroll)
+      const { viewport, scrollDirection, scrollDistance } = this.scrollToPosition(index)
+      viewport[scrollDirection] = scrollDistance
     },
 
-    scrollToPosition (position) {
+    scrollToPosition (index) {
+      const getPositionOfItem = (index) => {
+        if (this.itemSize === null) {
+          return index > 0 ? this.sizes[index - 1].accumulator : 0
+        } else {
+          return index * this.itemSize
+        }
+      }
+      const position = getPositionOfItem(index)
       const direction = this.direction === 'vertical'
         ? { scroll: 'scrollTop', start: 'top' }
         : { scroll: 'scrollLeft', start: 'left' }
@@ -585,11 +588,19 @@ export default {
 
         const scroller = this.$el.getBoundingClientRect()
         const scrollerPosition = scroller[direction.start] - viewport[direction.start]
-        viewportEl[direction.scroll] = position + scrollTop + scrollerPosition
-        return
+
+        return {
+          viewport: viewportEl,
+          scrollDirection: direction.scroll,
+          scrollDistance: position + scrollTop + scrollerPosition,
+        }
       }
 
-      this.$el[direction.scroll] = position
+      return {
+        viewport: this.$el,
+        scrollDirection: direction.scroll,
+        scrollDistance: position,
+      }
     },
 
     itemsLimitError () {

--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -573,11 +573,23 @@ export default {
     },
 
     scrollToPosition (position) {
-      if (this.direction === 'vertical') {
-        this.$el.scrollTop = position
-      } else {
-        this.$el.scrollLeft = position
+      const direction = this.direction === 'vertical'
+        ? { scroll: 'scrollTop', start: 'top', size: 'height' }
+        : { scroll: 'scrollLeft', start: 'left', size: 'width' }
+
+      if (this.pageMode) {
+        const viewportEl = ScrollParent(this.$el)
+        // HTML doesn't overflow like other elements
+        const scrollTop = viewportEl.tagName === 'HTML' ? 0 : viewportEl[direction.scroll]
+        const viewport = viewportEl.getBoundingClientRect()
+
+        const scroller = this.$el.getBoundingClientRect()
+        const scrollerPosition = scroller[direction.start] - viewport[direction.start]
+        viewportEl[direction.scroll] = position + scrollTop + scrollerPosition
+        return
       }
+
+      this.$el[direction.scroll] = position
     },
 
     itemsLimitError () {


### PR DESCRIPTION
x-pr from https://github.com/Akryum/vue-virtual-scroller/pull/396

> It has special logic when scrollToItem is called to take into account items that are before actual scroller. This is probably a fix to the #307 issue.