### PR TITLE
fix: clamp endIndex if less items than prerender

### DIFF
--- a/src/components/RecycleScroller.vue
+++ b/src/components/RecycleScroller.vue
@@ -295,7 +295,8 @@ export default {
         startIndex = endIndex = totalSize = 0
       } else if (this.$_prerender) {
         startIndex = 0
-        endIndex = this.prerender
+        // Don't cause an error from an OOB if items are less than the prerender amount
+        endIndex = Math.min(this.prerender, items.length)
         totalSize = null
       } else {
         const scroll = this.getScroll()


### PR DESCRIPTION
x-pr from https://github.com/Akryum/vue-virtual-scroller/pull/473

>Fixes an error I was getting in a component using this, where if `prerender` was greater than the amount of items I gave the scroller, it would try to get more items than available, causing an error from the item being undefined.